### PR TITLE
Add argument for specifying object properties to skip; handle i*.word…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -286,6 +286,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "colors": "1.3.1",
     "commander": "2.17.1",
     "deep-diff": "^1.0.1",
+    "is-url": "^1.2.4",
     "request": "^2.87.0",
     "winston": "^3.0.0"
   }


### PR DESCRIPTION
…press.com URLs; handle mismatches in HTML entities; ignore query strings when object property is a full URL